### PR TITLE
Change API request url

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -13,7 +13,7 @@ const ojosamaCmdCheck = () =>{
 
 const ojosama = async (text:string) =>{
     try{
-        const res = await axios.post(`${config.API}/api/ojosama`, {
+        const res = await axios.post(`${config.API}`, {
             Text: text
         })
         return res.data.Result;


### PR DESCRIPTION
## 変更内容

- API リクエスト先を新ドメインに変更しました

## 背景

ojosama の Web API は Heroku の無料枠で動かしているのですが、[Heroku無料プランの廃止](https://blog.heroku.com/next-chapter)が公式発表されました。
これに伴い、実行基盤を Heroku から AWS に変更することにしました。

基盤の変更に合わせて Web API のドメインも変更することにしましたので、
リクエスト先を新ドメインに変更します。

すでに新ドメインで API を使えるようにしているため、以下のコマンドで動作確認できます。
初回リクエスト時はやや時間がかかりますが、結果が返ってくるはずです。

```bash
curl -X POST -H 'Content-Type: application/json' -d '{"Text":"これはハーブです！"}' https://api.ojosama.jiro4989.com
```

旧ドメインの方は2022年10月中のどこかのタイミングで使えなくする予定です。

## ローカルでの動作確認ついて

https://github.com/Ablaze-MIRAI/ojosama-discord-channel/tree/main/api のコードを拝見するに、
ローカルで動作確認するために ojosama-web のソースコードをクローンしてビルドし、APIを公開するコンテナを立ち上げて動作確認できる作りになっているように見えます。

しかしながら、旧ドメインを廃止した後、 ojosama-web 側の Go のコードは削除する予定ですので、
いずれこちらの Docker を使ったローカルでの動作確認ができなくなります。

ローカルで動作確認できなくなってしまう問題については解決方法がいくつかあると思います。
API仕様は https://jiro4989.github.io/ojosama-web/swagger.html にて公開しているので

1. 固定値を返すモックサーバを立ち上げる
2. https://github.com/jiro4989/ojosama をライブラリとして呼び出してレスポンスを返すAPIサーバを実装する

などが考えられますが、このPRではそこまでは修正していません。

## 関連

https://github.com/jiro4989/ojosama-web/issues/23